### PR TITLE
Fix Starganizers url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@
 <br>
 
 ## 책이 유용하다고 생각하셨나요?👍
-- 깃허브 스타⭐를 통해 책을 지지해주세요!<br>책을 지지한 사람을 [Starganizers](https://github.com/seyoungcho2/coroutinelecture/stargazers) 페이지에서 볼 수 있습니다.
+- 깃허브 스타⭐를 통해 책을 지지해주세요!<br>책을 지지한 사람을 [Starganizers](https://github.com/seyoungcho2/coroutinelecture/stargazers) 페이지에서 볼 수 있습니다.
 - 강의가 어땠는지 수강평을 남겨주세요!


### PR DESCRIPTION
### 배경
Starganizers 를 클릭하면 공백이 포함된 링크로 접속되어 404이 발생합니다.

### 해결책
눈에 보이지 않는 공백을 제거합니다.

